### PR TITLE
feat: :zap: add mindee support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,39 @@ python src/evaluate_results.py [args]
 - `--dataset`: Dataset name (e.g. "Medical-Services")
 - `--output`: Evaluation result output JSON file path (optional, default: `<pred_file>_eval.json`)
 
+## :scientist: Run benchmark on Mindee API
+
+- Follow all repository set-up & data preparation steps.
+- The `Commercial` dataset is split by pages, reconstruct PDFs so that Mindee API can process each file as a whole.
+
+```bash
+python src/mindee/convert_commercial_dataset.py
+```
+Other datasets don't need any additional processing.
+
+- We need to generate a Mindee compatible dataschema.json file for each file. This is the KIE schema that will be applied by the API.
+
+```bash
+python src/mindee/generate_dataschemas.py
+```
+
+- Run the Mindee API on the all the datasets:
+You need a valid Mindee API key (get one [here](https://app.mindee.com)) and a model id.
+Take any model of your organization, the dataschema defining the fields to extract will be overidden at each API call with the generated dataschemas (see step above).
+
+```bash
+python src/mindee/run_inference.py --api-key=$MINDEE_API_KEY --model-id=ANY-MODEL-ID
+```
+
+- Finally run the provided evaluation script on each dataset:
+
+```bash
+python src/evaluate_results.py --pred out/Administrative/base/predictions.jsonl --dataset Administrative
+```
+
+Alternatively you can use the `scripts/eval.sh` to evaluate all datasets at once.
+
+
 ## 📝 Citation
 
 If you find our work to be of value and helpful to your research, please acknowledge our contributions by citing us in your publications or projects:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ aiofiles==25.1.0
 dashscope==1.25.2
 json_repair==0.54.2
 vllm==0.11.2
+mindee
+tqdm

--- a/src/mindee/convert_commercial_dataset.py
+++ b/src/mindee/convert_commercial_dataset.py
@@ -1,0 +1,64 @@
+"""Merge multi-page image subfolders in Commercial/images into single PDFs, so that mindee API can process them like a single document.
+
+Each subfolder under datasets/Commercial/images/ is treated as a multi-page
+document. The images inside are sorted by the first number found in their
+filename and combined into a single PDF named <subfolder>.pdf.
+"""
+
+import logging
+import re
+from pathlib import Path
+
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+IMAGES_DIR = REPO_ROOT / "datasets" / "Commercial" / "images"
+
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png"}
+
+
+def page_sort_key(filename: str) -> int:
+    """Extract the first integer from *filename* for sorting."""
+    m = re.search(r"(\d+)", filename)
+    return int(m.group(1)) if m else 0
+
+
+def merge_folder_to_pdf(folder: Path, output: Path) -> int:
+    """Convert all images in *folder* into a single PDF at *output*.
+
+    Returns the number of pages written.
+    """
+    pages = sorted(
+        [f.name for f in folder.iterdir() if f.suffix.lower() in IMAGE_EXTENSIONS],
+        key=page_sort_key,
+    )
+    if not pages:
+        return 0
+
+    images = [Image.open(folder / p).convert("RGB") for p in pages]
+    try:
+        images[0].save(output, save_all=True, append_images=images[1:])
+    finally:
+        for img in images:
+            img.close()
+
+    return len(pages)
+
+
+def main() -> None:
+    for entry in sorted(IMAGES_DIR.iterdir()):
+        if not entry.is_dir():
+            continue
+
+        pdf_path = IMAGES_DIR / f"{entry.name}.pdf"
+        n_pages = merge_folder_to_pdf(entry, pdf_path)
+        if n_pages:
+            logger.info(f"{entry.name}: {n_pages} pages -> {entry.name}.pdf")
+
+    logger.info("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mindee/generate_dataschemas.py
+++ b/src/mindee/generate_dataschemas.py
@@ -1,0 +1,179 @@
+"""Generate a Mindee-like dataschema.json per file for each dataset in datasets/.
+
+For a fair comparison of Mindee API performance across other models, we just add the name of each field
+as the name and title in the dataschema, without any additional guidelines or descriptions.
+The field type is always string, and all nested structures are flattened to a single level of nesting (with dotted titles
+indicating the original hierarchy), because the Mindee API only supports one level of nesting.
+"""
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+from unidecode import unidecode
+
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DATASETS_DIR = REPO_ROOT / "datasets"
+
+# Those names are reserved keywords in the Mindee API and would cause inference errors if used as-is.
+FORBIDDEN_NAMES = frozenset({"fields", "items", "value", "values", "item", "field"})
+FORBIDDEN_SUFFIX = "_"
+
+
+def to_snake_case(name: str) -> str:
+    """Convert a field name to lowercase snake_case, transliterating Unicode to ASCII."""
+    # Transliterate non-ASCII characters (e.g. Chinese, accented) to ASCII
+    s = unidecode(name)
+    # Insert underscore before uppercase letters preceded by lowercase
+    s = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s)
+    # Replace any non-alphanumeric characters with underscores
+    s = re.sub(r"[^a-zA-Z0-9]+", "_", s)
+    return s.strip("_").lower()
+
+
+def _sanitize_name(name: str) -> str:
+    """Suffix names that collide with reserved Mindee API keywords and truncate to 125 chars."""
+    if name in FORBIDDEN_NAMES:
+        name = name + FORBIDDEN_SUFFIX
+    return name[:125]
+
+
+def _sanitize_title(title: str) -> str:
+    """Suffix title components that collide with reserved Mindee API keywords and truncate to 125 chars."""
+    parts = title.split(".")
+    sanitized = [p + FORBIDDEN_SUFFIX if p.lower() in FORBIDDEN_NAMES else p for p in parts]
+    return ".".join(sanitized)[:125]
+
+
+def _make_string_field(name: str, title: str, is_array: bool = False) -> dict:
+    """Create a simple string field descriptor."""
+    return {
+        "name": _sanitize_name(name),
+        "type": "string",
+        "title": _sanitize_title(title),
+        "is_array": is_array,
+        "guidelines": "",
+        "description": "",
+        "nested_fields": [],
+        "unique_values": False,
+        "classification_values": []
+    }
+
+
+def _merge_list_keys(value_list: list[dict]) -> dict:
+    """Merge keys from all dict items in a list, keeping first occurrence value."""
+    merged = {}
+    for item in value_list:
+        if isinstance(item, dict):
+            for k, v in item.items():
+                if k not in merged:
+                    merged[k] = v
+    return merged
+
+
+def _build_subfields(obj: dict) -> list[dict]:
+    """Build nested_fields list, flattening any nested dicts/lists-of-dicts
+    to prevent double nesting (API only supports one level of nesting).
+
+    Flattened fields get a dotted title (e.g. 'sub.nm') so that
+    run_inference can reconstruct the original nested structure.
+    """
+    fields = []
+    for k, v in obj.items():
+        if isinstance(v, dict):
+            # Would create double nesting — flatten with prefix, dotted title
+            for sub_k in v:
+                fields.append(_make_string_field(
+                    to_snake_case(f"{k}_{sub_k}"), f"{k}.{sub_k}"
+                ))
+        elif isinstance(v, list) and v and isinstance(v[0], dict):
+            # Would create double nesting — flatten with prefix, dotted title
+            all_keys = _merge_list_keys(v)
+            for sub_k in all_keys:
+                fields.append(_make_string_field(
+                    to_snake_case(f"{k}_{sub_k}"), f"{k}.{sub_k}"
+                ))
+        elif isinstance(v, list):
+            # Array of scalars
+            fields.append(_make_string_field(to_snake_case(k), k, is_array=True))
+        else:
+            # Simple scalar
+            fields.append(_make_string_field(to_snake_case(k), k))
+    return fields
+
+
+def make_field(name: str, value: Any = None) -> dict:
+    """Build a dataschema field descriptor, supporting nested objects and arrays.
+
+    When value is provided, the structure is inferred:
+    - dict -> nested_object with nested_fields (sub-nested objects are flattened)
+    - list of dicts -> nested_object with is_array=True (sub-nested flattened)
+    - list of strings -> string with is_array=True
+    - otherwise -> string
+    """
+    snake = to_snake_case(name)
+
+    if isinstance(value, dict):
+        nested = _build_subfields(value)
+        return {
+            "name": _sanitize_name(snake),
+            "type": "nested_object",
+            "title": _sanitize_title(name),
+            "is_array": False,
+            "guidelines": "",
+            "description": "",
+            "nested_fields": nested,
+            "unique_values": False,
+            "classification_values": []
+        }
+
+    if isinstance(value, list):
+        if value and isinstance(value[0], dict):
+            merged = _merge_list_keys(value)
+            nested = _build_subfields(merged)
+            return {
+                "name": _sanitize_name(snake),
+                "type": "nested_object",
+                "title": _sanitize_title(name),
+                "is_array": True,
+                "guidelines": "",
+                "description": "",
+                "nested_fields": nested,
+                "unique_values": False,
+                "classification_values": []
+            }
+        return _make_string_field(snake, name, is_array=True)
+
+    return _make_string_field(snake, name)
+
+
+def main() -> None:
+    for dataset_dir in sorted(DATASETS_DIR.iterdir()):
+        label_path = dataset_dir / "label.json"
+        if not label_path.is_file():
+            continue
+
+        labels = json.loads(label_path.read_text(encoding="utf-8"))
+
+        out_dir = dataset_dir / "dataschemas"
+        out_dir.mkdir(exist_ok=True)
+
+        count = 0
+        for filename, entry in labels.items():
+            schema = [make_field(key, value) for key, value in entry.items()]
+
+            out_path = out_dir / f"{filename}.json"
+            out_path.write_text(
+                json.dumps(schema, indent=2, ensure_ascii=False), encoding="utf-8"
+            )
+            count += 1
+
+        logger.info(f"{dataset_dir.name}: {count} files -> {out_dir}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mindee/run_inference.py
+++ b/src/mindee/run_inference.py
@@ -1,0 +1,313 @@
+"""Run Mindee API inference on all datasets and store results in label.json format."""
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+from mindee import BytesInput, ClientV2, InferenceParameters, InferenceResponse
+from tqdm import tqdm
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".tif", ".tiff", ".bmp", ".webp", ".pdf"}
+
+FORBIDDEN_SUFFIX = "_"
+
+
+def _unsanitize_title(title: str) -> str:
+    """Strip the forbidden-name suffix added by generate_dataschemas from title components."""
+    parts = title.split(".")
+    cleaned = [p[:-len(FORBIDDEN_SUFFIX)] if p.endswith(FORBIDDEN_SUFFIX) else p for p in parts]
+    return ".".join(cleaned)
+
+
+def discover_datasets(base_path: Path) -> list[str]:
+    """Discover datasets that have both images/ and dataschemas/ with content."""
+    datasets = []
+    for d in sorted(base_path.iterdir()):
+        if not d.is_dir():
+            continue
+        images_dir = d / "images"
+        schemas_dir = d / "dataschemas"
+        if images_dir.exists() and schemas_dir.exists() and any(schemas_dir.iterdir()):
+            datasets.append(d.name)
+    return datasets
+
+
+def find_image_for_schema(schema_file: Path, images_dir: Path) -> Path | None:
+    """Find the image file corresponding to a dataschema file.
+
+    Schema naming conventions:
+    - 'hot-0300.jpg.json' -> image 'hot-0300.jpg'
+    - '009bdcdec5c04cd3b2e31555.json' -> image '009bdcdec5c04cd3b2e31555.pdf'
+    """
+    # Remove .json suffix to get the candidate image name
+    candidate = schema_file.stem  # e.g. 'hot-0300.jpg' or '009bdcdec5c04cd3b2e31555'
+
+    # If candidate already has an image extension, look for it directly
+    candidate_path = images_dir / candidate
+    if candidate_path.is_file():
+        return candidate_path
+
+    # Otherwise try common image extensions
+    for ext in IMAGE_EXTENSIONS:
+        test_path = images_dir / f"{candidate}{ext}"
+        if test_path.is_file():
+            return test_path
+
+    return None
+
+
+def get_label_key(image_path: Path) -> str:
+    """Derive the label key from the image path, matching label.json conventions.
+
+    - JPG/image files: key includes extension (e.g. 'hot-0300.jpg')
+    - PDF files: key is stem only (e.g. '009bdcdec5c04cd3b2e31555')
+    """
+    if image_path.suffix.lower() == ".pdf":
+        return image_path.stem
+    return image_path.name
+
+
+def build_name_to_title(fields: list[dict]) -> dict:
+    """Build a name -> (title, nested_mapping) mapping from the dataschema fields."""
+    mapping = {}
+    for f in fields:
+        nested_map = {}
+        if f.get("nested_fields"):
+            nested_map = build_name_to_title(f["nested_fields"])
+        mapping[f["name"]] = {"title": _unsanitize_title(f["title"]), "nested": nested_map}
+    return mapping
+
+
+def _unwrap(data: object) -> object:
+    """Recursively strip confidence/locations wrappers, unwrap fields/items/value."""
+    if isinstance(data, list):
+        return [_unwrap(i) for i in data]
+    if not isinstance(data, dict):
+        return data
+    if "fields" in data and isinstance(data["fields"], dict):
+        return {k: _unwrap(v) for k, v in data["fields"].items()}
+    if "items" in data and isinstance(data["items"], list):
+        return [_unwrap(i) for i in data["items"]]
+    if "value" in data and ("confidence" in data or "locations" in data):
+        return data["value"] or ""
+    return {k: _unwrap(v) for k, v in data.items()}
+
+
+def extract_prediction_fields(inference_result: dict, field_mapping: dict) -> dict:
+    """Extract field title -> value mapping from the Mindee inference result."""
+    result = {}
+    for field_name, raw in inference_result.items():
+        info = field_mapping.get(field_name, {"title": field_name, "nested": {}})
+        title, nested_map = info["title"], info["nested"]
+        field_data = _unwrap(raw)
+
+        if isinstance(field_data, list) and field_data and isinstance(field_data[0], dict):
+            result[title] = [
+                {nested_map.get(k, {"title": k})["title"]: v for k, v in item.items()}
+                for item in field_data
+            ]
+        elif isinstance(field_data, dict) and "value" not in field_data:
+            result[title] = {
+                nested_map.get(k, {"title": k})["title"]: v for k, v in field_data.items()
+            }
+        elif isinstance(field_data, dict) and "value" in field_data:
+            result[title] = field_data.get("value") or ""
+        else:
+            result[title] = field_data
+    return result
+
+
+def _unflatten_dotted(obj: dict, label_template) -> dict:
+    """Convert keys with dots (e.g. 'sub.nm') back into nested dicts/lists.
+
+    Uses label_template to determine whether to reconstruct as dict or list.
+    """
+    result = {}
+    nested_groups = {}  # parent -> {child: value}
+
+    for key, value in obj.items():
+        if "." in str(key):
+            parent, child = str(key).split(".", 1)
+            if parent not in nested_groups:
+                nested_groups[parent] = {}
+            nested_groups[parent][child] = value
+        else:
+            result[key] = value
+
+    for parent, children in nested_groups.items():
+        if isinstance(label_template, dict):
+            label_val = label_template.get(parent)
+            if isinstance(label_val, list):
+                result[parent] = [children]
+            else:
+                result[parent] = children
+        else:
+            result[parent] = children
+
+    return result
+
+
+def reconstruct_nested(prediction: dict, label_entry: dict) -> dict:
+    """Reconstruct flattened dotted keys back into the original nested structure.
+
+    Uses label_entry from label.json to determine list vs dict for each field.
+    """
+    result = {}
+    for key, value in prediction.items():
+        if isinstance(value, list) and value and isinstance(value[0], dict):
+            # Array of objects — unflatten each row
+            label_val = label_entry.get(key, [])
+            if isinstance(label_val, list) and label_val and isinstance(label_val[0], dict):
+                sample = label_val[0]
+            elif isinstance(label_val, dict):
+                sample = label_val
+            else:
+                sample = {}
+            result[key] = [_unflatten_dotted(item, sample) for item in value]
+        elif isinstance(value, dict):
+            # Nested object — unflatten
+            label_val = label_entry.get(key, {})
+            result[key] = _unflatten_dotted(value, label_val)
+        else:
+            result[key] = value
+    return result
+
+
+def process_dataset(
+    dataset_name: str,
+    base_path: Path,
+    mindee_client: ClientV2,
+    model_id: str,
+    output_path: Path,
+    confidence: bool = False,
+) -> list[dict]:
+    """Process a single dataset: run inference on each (image, dataschema) pair."""
+    dataset_path = base_path / dataset_name
+    images_dir = dataset_path / "images"
+    schemas_dir = dataset_path / "dataschemas"
+
+    schema_files = sorted(schemas_dir.glob("*.json"))
+    if not schema_files:
+        logger.warning(f"No dataschemas found for {dataset_name}, skipping")
+        return []
+
+    # Load label.json for structure reference (used for nested reconstruction)
+    label_path = dataset_path / "label.json"
+    labels_structure = json.loads(label_path.read_text()) if label_path.exists() else {}
+
+    entries = []
+    failed = []
+
+    for schema_file in tqdm(schema_files, desc=f"  {dataset_name}"):
+        image_path = find_image_for_schema(schema_file, images_dir)
+        if image_path is None:
+            logger.warning(f"No image found for schema {schema_file.name}")
+            failed.append(schema_file.name)
+            continue
+
+        label_key = get_label_key(image_path)
+
+        # Load per-image dataschema
+        fields = json.loads(schema_file.read_text())
+        data_schema = json.dumps({"replace": {"fields": fields}})
+                
+        params = InferenceParameters(
+            model_id=model_id,
+            data_schema=data_schema,
+            confidence=confidence,
+        )
+        response = mindee_client.enqueue_and_get_result(
+            response_type=InferenceResponse,
+            input_source=BytesInput(image_path.read_bytes(), filename=image_path.name),
+            params=params,
+        )
+        inference = response._raw_http["inference"]["result"]["fields"]
+
+        # Build recursive name -> title mapping from the dataschema
+        field_mapping = build_name_to_title(fields)
+        prediction = extract_prediction_fields(inference, field_mapping)
+
+        # Reconstruct flattened dotted keys back into original nested structure
+        label_entry = labels_structure.get(label_key, {})
+        prediction = reconstruct_nested(prediction, label_entry)
+
+        entries.append({
+            "dataset": dataset_name,
+            "url": f"images/{label_key}",
+            "model_result": prediction,
+        })
+        logger.info(f"  ✓ {label_key}")
+
+    # Write per-dataset JSONL output
+    mode_dir = "confidence" if confidence else "base"
+    out_file = output_path / dataset_name / mode_dir / "predictions.jsonl"
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_file, "w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+    logger.info(
+        f"{dataset_name}: {len(entries)}/{len(schema_files)} succeeded, "
+        f"{len(failed)} failed -> {out_file}"
+    )
+    return entries
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run Mindee API inference on all datasets and store results as predictions.json"
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.environ.get("MINDEE_API_KEY"),
+        help="Mindee API key (default: $MINDEE_API_KEY)",
+    )
+    parser.add_argument("--base-url", default="https://api-v2.mindee.net", help="API base URL")
+    parser.add_argument("--datasets-path", type=Path, default=Path("datasets"), help="Datasets dir")
+    parser.add_argument("--output", type=Path, default=Path("out"), help="Output directory")
+    parser.add_argument(
+        "--confidence", action="store_true", default=False,
+        help="Enable confidence scores in inference results.",
+    )
+    parser.add_argument(
+        "--model-id",
+        required=True,
+        help="Model ID (same org as api-key); dataschema is overridden per image.",
+    )
+    args = parser.parse_args()
+
+    if not args.api_key:
+        parser.error("--api-key is required (or set $MINDEE_API_KEY)")
+
+    os.environ["MINDEE_V2_BASE_URL"] = f"{args.base_url}/v2"
+    mindee_client = ClientV2(args.api_key)
+
+    datasets = discover_datasets(args.datasets_path)
+    logger.info(f"Found {len(datasets)} datasets: {', '.join(datasets)}")
+
+    if not datasets:
+        logger.error("No datasets found")
+        sys.exit(1)
+
+    total = 0
+    for ds in datasets:
+        logger.info(f"--- {ds} ---")
+        entries = process_dataset(ds, args.datasets_path, mindee_client, args.model_id, args.output, args.confidence)
+        total += len(entries)
+
+    logger.info(f"Wrote {total} predictions across {len(datasets)} datasets")
+    sys.exit(0 if total else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces a new workflow for benchmarking datasets using the Mindee API, including data preprocessing, schema generation, and inference. It adds three new scripts to automate PDF reconstruction for the Commercial dataset, generate Mindee-compatible data schemas for all datasets, and run inference with the Mindee API. The `README.md` is updated with detailed instructions for using these scripts.

**Mindee API Benchmarking Workflow:**

*Documentation and Usage:*
- Added a new section to `README.md` explaining how to run benchmarks on the Mindee API, including step-by-step instructions for data preparation, schema generation, inference, and evaluation.

*Dataset Preprocessing:*
- Added `src/mindee/convert_commercial_dataset.py` to merge multi-page image folders in the Commercial dataset into single PDFs, enabling the Mindee API to process each document as a whole.

*Data Schema Generation:*
- Added `src/mindee/generate_dataschemas.py` to generate a Mindee-compatible `dataschema.json` for each file in each dataset, flattening doubly nested structures and ensuring compatibility with Mindee API requirements.

*Inference Pipeline:*
- Added `src/mindee/run_inference.py` to automate running inference with the Mindee API across all datasets, reconstructing nested prediction outputs to match original label structures and saving results in the required format of the UNIKIE benchmark for evaluation.